### PR TITLE
Autoware lidar tidy up

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,2 +1,1 @@
-#HOST_DATA_PATH=/home/user/cavas_data
 HOST_DATA_PATH=/home/lincolncavas23/Desktop/autoware_docker/data

--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,2 @@
+#HOST_DATA_PATH=/home/user/cavas_data
 HOST_DATA_PATH=/home/lincolncavas23/Desktop/autoware_docker/data

--- a/docker/autoware.dockerfile
+++ b/docker/autoware.dockerfile
@@ -29,10 +29,21 @@ RUN apt-get update && \
         apt-transport-https \
         ros-$ROS_DISTRO-pacmod3
 
-# Install the RMW Implementation
+# Setup .bashrc
+RUN echo "" >> ~/.bashrc && \
+    echo "# Added from autoware.dockerfile build" >> ~/.bashrc
+
+# Install DDS
 ENV rmw_implementation_dashed=rmw-cyclonedds-cpp
 RUN apt-get update && \
     apt-get install -y ros-humble-${rmw_implementation_dashed}
+
+# Add Cyclonedds.xml DDS resource
+ADD resources/cyclonedds.xml /resources/cyclonedds.xml
+
+# Setup DDS settings
+RUN echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> ~/.bashrc && \
+    echo "export CYCLONEDDS_URI=file:///resources/cyclonedds.xml" >> ~/.bashrc
 
 # Install Nvidia CUDA Toolkit
 ENV cuda_version_dashed=11-6
@@ -101,16 +112,9 @@ RUN /bin/bash -c "cd autoware && \
 
 # Setup .bashrc
 RUN sed -i 's|# source /autoware/install/setup.bash|source /autoware/install/setup.bash|' ~/.bashrc
-
-# Add Cyclonedds.xml Resource
-RUN resources/cyclonedds.xml /resources/cyclonedds.xml
-
-# Setup DDS settings
-RUN sh -c 'echo '' >> ~/.bashrc && echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> ~/.bashrc' \
-    'echo '' >> ~/.bashrc && echo "export CYCLONEDDS_URI=file:///resources/cyclonedds.xml" >> ~/.bashrc'    
-
-# Add Map resources
+   
+# Add map resources
 ADD resources/service_road_corrected/ /resources/service_road_corrected/
 
-# Apply Temp. Patches (Will be removed ASAP)
+# Apply temp. patches (will be removed ASAP)
 ADD resources/sensor_kit_calibration.yaml /autoware/src/param/autoware_individual_params/individual_params/config/default/awsim_sensor_kit/sensor_kit_calibration.yaml

--- a/docker/autoware.dockerfile
+++ b/docker/autoware.dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update && \
 ENV rmw_implementation_dashed=rmw-cyclonedds-cpp
 RUN apt-get update && \
     apt-get install -y ros-humble-${rmw_implementation_dashed}
-RUN sh -c 'echo '' >> ~/.bashrc && echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> ~/.bashrc'
 
 # Install Nvidia CUDA Toolkit
 ENV cuda_version_dashed=11-6
@@ -103,9 +102,15 @@ RUN /bin/bash -c "cd autoware && \
 # Setup .bashrc
 RUN sed -i 's|# source /autoware/install/setup.bash|source /autoware/install/setup.bash|' ~/.bashrc
 
+# Add Cyclonedds.xml Resource
+RUN resources/cyclonedds.xml /resources/cyclonedds.xml
+
+# Setup DDS settings
+RUN sh -c 'echo '' >> ~/.bashrc && echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> ~/.bashrc' \
+    'echo '' >> ~/.bashrc && echo "export CYCLONEDDS_URI=file:///resources/cyclonedds.xml" >> ~/.bashrc'    
+
 # Add Map resources
 ADD resources/service_road_corrected/ /resources/service_road_corrected/
-
 
 # Apply Temp. Patches (Will be removed ASAP)
 ADD resources/sensor_kit_calibration.yaml /autoware/src/param/autoware_individual_params/individual_params/config/default/awsim_sensor_kit/sensor_kit_calibration.yaml

--- a/docker/resources/cyclonedds.xml
+++ b/docker/resources/cyclonedds.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+  <Domain Id="any">
+    <General>
+      <Interfaces>
+        <NetworkInterface autodetermine="false" name="lo" priority="default" multicast="default" />
+      </Interfaces>
+      <AllowMulticast>default</AllowMulticast>
+      <MaxMessageSize>65500B</MaxMessageSize>
+    </General>
+    <Internal>
+      <SocketReceiveBufferSize min="10MB"/>
+      <Watermarks>
+        <WhcHigh>500kB</WhcHigh>
+      </Watermarks>
+    </Internal>
+  </Domain>
+</CycloneDDS>

--- a/docker/ros2.dockerfile
+++ b/docker/ros2.dockerfile
@@ -27,10 +27,6 @@ RUN mkdir -p /tmp/downloads && \
 # Make /ros_ws/src folder    
 RUN mkdir -p /ros_ws/src
 
-# Clone Velodyne Src
-RUN cd /ros_ws/src && \
-    git clone https://github.com/ros-drivers/velodyne.git 
-
 # Clone VimbaX ROS2 Driver
 RUN cd /ros_ws/src && \
     git clone https://github.com/ub-cavas/vimbax_ros2_driver.git
@@ -56,9 +52,3 @@ RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc && \
     echo "# source /autoware/install/setup.bash" >> ~/.bashrc && \
     echo "source /ros_ws/install/local_setup.bash" >> ~/.bashrc && \
     echo "cd /ros_ws" >> ~/.bashrc
-
-
-# Apply Temp. Patches (Will be removed ASAP)
-COPY resources/velodyne-all-nodes-VLP32C-composed-launch.py /ros_ws/src/velodyne/velodyne/launch/velodyne-all-nodes-VLP32C-composed-launch.py
-COPY resources/VLP32C-velodyne_driver_node-params.yaml /ros_ws/src/velodyne/velodyne_driver/config/VLP32C-velodyne_driver_node-params.yaml
-COPY resources/VLP32C-velodyne_transform_node-params.yaml /ros_ws/src/velodyne/velodyne_pointcloud/config/VLP32C-velodyne_transform_node-params.yaml

--- a/docker/ros2.dockerfile
+++ b/docker/ros2.dockerfile
@@ -27,6 +27,10 @@ RUN mkdir -p /tmp/downloads && \
 # Make /ros_ws/src folder    
 RUN mkdir -p /ros_ws/src
 
+# Setup .bashrc
+RUN echo "" >> ~/.bashrc && \
+    echo "# Added from ros2.dockerfile build" >> ~/.bashrc
+
 # Clone VimbaX ROS2 Driver
 RUN cd /ros_ws/src && \
     git clone https://github.com/ub-cavas/vimbax_ros2_driver.git


### PR DESCRIPTION
In Autoware Dockerfile:
- Added cyclone.dds file in resources which is then again added in the resources folder of the image similiar to the maps. 
- Moved `RMW_IMPLEMENTATION` towards the end since the cyclonedds.dds file path and export `RMW_IMPLMENTATION` need to be consequently done.

In ROS2 Dockerfile:
- Removed the cloning of `velodyne driver` repository and source building it in `ros_ws`. The image now has the binary installations of all the drivers except the camera.
